### PR TITLE
Build Alpine image

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -7,6 +7,10 @@ on:
   release:
     types: [published]
 
+env:
+  DOCKER_BUILDKIT: 1
+  DOCKER_TAG_PREFIX: ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}
+
 jobs:
   docker:
     runs-on: ubuntu-latest
@@ -27,32 +31,52 @@ jobs:
           skip-unshallow: 'true'
           abbrev: 7
       -
-        name: Determine image tag type
+        name: Determine scratch image tag type
         uses: haya14busa/action-cond@v1
-        id: imgtag
+        id: imgtag_scratch
         with:
           cond: ${{ github.event_name == 'release' }}
-          if_true: ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}:${{ github.event.release.tag_name }},${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}:latest
-          if_false: ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}:latest
+          if_true: ${{ env.DOCKER_TAG_PREFIX }}:${{ github.event.release.tag_name }},${{ env.DOCKER_TAG_PREFIX }}:latest
+          if_false: ${{ env.DOCKER_TAG_PREFIX }}:latest
+      -
+        name: Determine Alpine image tag type
+        uses: haya14busa/action-cond@v1
+        id: imgtag_alpine
+        with:
+          cond: ${{ github.event_name == 'release' }}
+          if_true: ${{ env.DOCKER_TAG_PREFIX }}:${{ github.event.release.tag_name }}-alpine,${{ env.DOCKER_TAG_PREFIX }}:latest-alpine
+          if_false: ${{ env.DOCKER_TAG_PREFIX }}:latest-alpine
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       -
         name: Login to DockerHub
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v2 
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
-        name: Build and push
-        id: docker_build
-        uses: docker/build-push-action@v2
+        name: Build and push scratch image
+        id: docker_build_scratch
+        uses: docker/build-push-action@v4
         with:
           context: .
           platforms: linux/amd64,linux/arm64,linux/386,linux/arm/v7
           push: true
-          tags: ${{ steps.imgtag.outputs.value }}
-          build-args: 'GIT_DESC=${{steps.tagger.outputs.tag}}'
+          tags: ${{ steps.imgtag_scratch.outputs.value }}
+          target: scratch
+          build-args: 'GIT_DESC=${{ steps.tagger.outputs.tag }}'
+      -
+        name: Build and push Alpine image
+        id: docker_build_alpine
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64,linux/386,linux/arm/v7
+          push: true
+          tags: ${{ steps.imgtag_alpine.outputs.value }}
+          target: alpine
+          build-args: 'GIT_DESC=${{ steps.tagger.outputs.tag }}'

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,16 @@ RUN CGO_ENABLED=0 go build -a -tags netgo -ldflags '-s -w -extldflags "-static" 
 ADD https://curl.haxx.se/ca/cacert.pem /certs.crt
 RUN chmod 0644 /certs.crt
 
-FROM scratch AS arrange
+FROM scratch AS scratch
 COPY --from=build /go/src/github.com/Snawoot/dumbproxy/dumbproxy /
 COPY --from=build /certs.crt /etc/ssl/certs/ca-certificates.crt
+USER 9999:9999
+EXPOSE 8080/tcp
+ENTRYPOINT ["/dumbproxy", "-bind-address", ":8080"]
 
-FROM scratch
-COPY --from=arrange / /
+FROM alpine AS alpine
+COPY --from=build /go/src/github.com/Snawoot/dumbproxy/dumbproxy /
+COPY --from=build /certs.crt /etc/ssl/certs/ca-certificates.crt
 USER 9999:9999
 EXPOSE 8080/tcp
 ENTRYPOINT ["/dumbproxy", "-bind-address", ":8080"]


### PR DESCRIPTION
Build an image based on Alpine:
- name build stages (scratch and alpine respectively) to use them as targets during a build
- set `DOCKER_BUILDKIT` to build only required stages within one `Dockerfile`
- improve tagging mechanism
- bump GitHub Actions versions to get rid of warnings about "save-state deprecation"